### PR TITLE
force colored output from Data::Printer

### DIFF
--- a/lib/Reply/Plugin/DataPrinter.pm
+++ b/lib/Reply/Plugin/DataPrinter.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base 'Reply::Plugin';
 
-use Data::Printer alias => 'p';
+use Data::Printer alias => 'p', colored => 1;
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Data::Printer's output in Reply doesn't come out colored because Reply takes the dump in a variable (thus triggering wantarray which Data::Printer uses to distinguish between printing and returning the dump).

This forced Data::Printer to returned colored output. This provides a much needed beautiful colored output to the user.

The only caveat (which you might care about) is that other plugins that might want to munge the output dump (and why would they?!) will get the ANSI color codes inlined in the text. Then again, maybe coloring should just be assured to be the _last_ plugin.

Either way, enjoy, and thank you for Reply! :)
