### PR TITLE
New CollapseStack plugin

### DIFF
--- a/lib/Reply/Plugin/CollapseStack.pm
+++ b/lib/Reply/Plugin/CollapseStack.pm
@@ -1,0 +1,64 @@
+package Reply::Plugin::CollapseStack;
+use strict;
+use warnings;
+# ABSTRACT: display error stack traces only on demand
+
+use base 'Reply::Plugin';
+
+=head1 SYNOPSIS
+
+  ; .replyrc
+  [CollapseStack]
+  num_lines = 1
+
+=head1 DESCRIPTION
+
+This plugin hides stack traces until you specifically request them
+with the C<#stack> command.
+
+The number of lines of stack to always show is configurable; specify
+the C<num_lines> option.
+
+=cut
+
+sub new {
+    my $class = shift;
+    my %opts = @_;
+
+    my $self = $class->SUPER::new(@_);
+    $self->{num_lines} = $opts{num_lines} || 1;
+
+    return $self;
+}
+
+sub mangle_error {
+    my $self = shift;
+    my $error = shift;
+
+    $self->{full_error} = $error;
+
+    my @lines = split /\n/, $error;
+    if (@lines > $self->{num_lines}) {
+        splice @lines, $self->{num_lines};
+        $error = join "\n", @lines, "    (Run #stack to see the full trace)";
+    }
+
+    return $error;
+}
+
+sub command_stack {
+    my $self = shift;
+
+    # XXX should use print_error here
+    print($self->{full_error} || "No stack to display.\n");
+
+    return '';
+}
+
+=for Pod::Coverage
+  command_stack
+
+=cut
+
+1;
+


### PR DESCRIPTION
Next steps:
- Catch warnings too (I think this needs core management of warnings, just like what exists for errors)
- Provide a `print_error` (and `print_warning`) to plugins so the output can be colored, etc. I _think_ `print_error` should include `mangle_error` (which I can deal with in the CollapseStack plugin)
- @doy also suggested using `Carp::Always` as part of this. +1
