### PR TITLE
Support Term::ReadLine::Perl5

### DIFF
--- a/lib/Reply/Plugin/ReadLine.pm
+++ b/lib/Reply/Plugin/ReadLine.pm
@@ -46,6 +46,11 @@ sub new {
         $history
     );
 
+    if ($self->{term}->ReadLine eq 'Term::ReadLine::Perl5') {
+        # output compatible with Term::ReadLine::Gnu
+        $readline::rl_scroll_nextline = 0;
+    }
+
     if ($self->{term}->ReadLine eq ('Term::ReadLine::Gnu' or 'Term::ReadLine::Perl5')) {
         $self->{term}->StifleHistory($opts{history_length})
             if defined $opts{history_length} && $opts{history_length} >= 0;


### PR DESCRIPTION
Enable autocomplete in Term::ReadLine::Perl5, and make output of Term::ReadLine::Perl5 compatible with Term::ReadLine::Gnu.

It is a little hard to install Term::ReadLine::Gnu in OS X because of license problem.
So, if autocomplete can be used with Term::ReadLine::Perl5 (this doesn't cause license problem), it become more useful.
