### PR TITLE
Fix execute context in Reply::Plugin::Timer

### DIFF
--- a/lib/Reply/Plugin/Timer.pm
+++ b/lib/Reply/Plugin/Timer.pm
@@ -35,7 +35,7 @@ sub execute {
     my ($self, $next, @args) = @_;
 
     my $t0 = [gettimeofday];
-    my $ret = $next->(@args);
+    my @ret = $next->(@args);
     my $elapsed = tv_interval($t0);
 
     if ($elapsed > $self->{mintime}) {
@@ -46,7 +46,7 @@ sub execute {
         }
     }
 
-    return $ret;
+    return @ret;
 }
 
 1;


### PR DESCRIPTION
Otherwise it breaks calling anything that returns a list.

Also, the Reply::Plugin documentation says the execute method "returns
the list of results returned by calling the coderef."
