### PR TITLE
Unshift onto @INC instead of pushing when using -I/-l/-b

### DIFF
--- a/lib/Reply/App.pm
+++ b/lib/Reply/App.pm
@@ -46,9 +46,9 @@ sub run {
     my $parsed = GetOptionsFromArray(
         \@argv,
         'cfg:s'   => \$cfgfile,
-        'l|lib'   => sub { push @INC, 'lib' },
-        'b|blib'  => sub { push @INC, 'blib/lib', 'blib/arch' },
-        'I:s@'    => sub { push @INC, $_[1] },
+        'l|lib'   => sub { unshift @INC, 'lib' },
+        'b|blib'  => sub { unshift @INC, 'blib/lib', 'blib/arch' },
+        'I:s@'    => sub { unshift @INC, $_[1] },
         'M:s@'    => \@modules,
         'e:s@'    => \@script_lines,
         'version' => sub { $exitcode = 0; version() },


### PR DESCRIPTION
This is what perl does for -I, and what prove does for -l and -b, so
let's be consistent.
