### PR TITLE
Make Plugin::DataPrinter a little quieter

### DIFF
--- a/lib/Reply/Plugin/DataPrinter.pm
+++ b/lib/Reply/Plugin/DataPrinter.pm
@@ -20,6 +20,7 @@ This plugin uses L<Data::Printer> to format results.
 
 sub mangle_result {
     my ($self, @result) = @_;
+    return unless @result;
     return p(@result, return_value => 'dump');
 }
 

--- a/lib/Reply/Plugin/DataPrinter.pm
+++ b/lib/Reply/Plugin/DataPrinter.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base 'Reply::Plugin';
 
-use Data::Printer alias => 'p', colored => 1;
+use Data::Printer alias => 'p', colored => 1, return_value => 'dump';
 
 =head1 SYNOPSIS
 

--- a/lib/Reply/Plugin/DataPrinter.pm
+++ b/lib/Reply/Plugin/DataPrinter.pm
@@ -21,7 +21,8 @@ This plugin uses L<Data::Printer> to format results.
 sub mangle_result {
     my ($self, @result) = @_;
     return unless @result;
-    return p(@result, return_value => 'dump');
+    ( @result == 1 ) && return p($result[0]);
+    return p(@result);
 }
 
 1;


### PR DESCRIPTION
This change should make DataPrinter a little more like the other output plugins by quashing output if there is no result.
- Before

```
$ reply
$res[-1] = []
$res[-1] = []
$res[-1] = []
0> sub foo {}
$res[-1] = []
1> foo
$res[-1] = []
2> 
$res[-1] = []
3> 
$res[-1] = []
4> 
$res[-1] = []
5> undef
$res[0] = [
    [0] undef
]
```
- After

```
$ reply
0> sub foo {}
1> foo
2> 
3> 
4> 
5> undef
$res[0] = undef
```
- DataDumper

```
$ reply
0> sub foo {}
1> foo
2> 
3> 
4> 
5> undef
$res[0] = undef
```

Thanks!
