### PR TITLE
Editor.pm: echo back text input

### DIFF
--- a/lib/Reply/Plugin/Editor.pm
+++ b/lib/Reply/Plugin/Editor.pm
@@ -26,6 +26,14 @@ the contents of that file will be preloaded instead.
 The C<editor> option can be specified to provide a different editor to use,
 otherwise it will use the value of C<$ENV{VISUAL}> or C<$ENV{EDITOR}>.
 
+The C<echo> option can be used to suppress or enable the display in reply
+itself of the text inserted through the editor.
+
+=head1 BUGS
+
+Despite the C<echo> option being enabled, output will not be available through
+the C<Nopaste> plugin.
+
 =cut
 
 sub new {
@@ -38,6 +46,7 @@ sub new {
             ? (editors => [ $opts{editor} ])
             : ())
     );
+    $self->{echo} = $opts{echo};
     $self->{current_text} = '';
 
     return $self;
@@ -73,6 +82,10 @@ sub command_e {
         $self->{current_text} = $text;
     }
 
+    if($self->{echo}) {
+      say $text;
+    }
+    
     return $text;
 }
 


### PR DESCRIPTION
If you use #e the following things break:

1. once you leave the editor, your terminal only shows #e, not your code
2. Nopaste, if enabled, only shows your #e, not your code

This fixes issue 1 in the simplest way possible, without fixing, or attempting to fix issue 2. Loading Editor before Nopaste does not help.

A more featureful implementation would require some way for plugins to talk to each other. For example, I'd have liked the pasted text to appear visually indented to the prompt, but that requires knowing if FancyPrompt is loaded, and what is the value of its counter. I saw no obvious way to achieve this. Nopaste not being able to capture the line is also unfortunate, though I haven't really looked into ways to make it work.

It is also possible that a bare 'say' is too simplistic in term of encoding issues:

```
> reply                        
0> #e                                       
say "ããããªã"                       
ããããªã                             
$res[0] = 1                                 

2> use utf8                                 
3> #e                                       
say "ããããªã"                       
さようなら                                  
$res[1] = 1                                 

4> binmode(STDOUT, ":utf8");                                                                                                                                                     
$res[2] = 1                                 

5> #e
say "ããããªã "
さようなら
$res[3] = 1
```