### PR TITLE
Reply::Plugin::Multiline::PPI for multiline input support

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Reply
 
 {{$NEXT}}
 
+      - Add Reply::Plugin::Multiline::PPI for a multiline input support
+
 0.42  2016-08-23
       - make tests pass again if Term::ReadKey is not installed (andk, #52)
 

--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,7 @@ skip = ^lib/Reply/Util.pm$
 :version = 0.14
 dist = Reply
 repository = github
-Test::Compile_skip = ::(?:CollapseStack|Nopaste|DataDump|DataPrinter|Editor|AutoRefresh|Autocomplete::Keywords|Pager)$
+Test::Compile_skip = ::(?:CollapseStack|Nopaste|DataDump|DataPrinter|Editor|AutoRefresh|Autocomplete::Keywords|Pager|Multiline::PPI)$
 PodWeaver_finder = WeaverFiles
 
 [MetaNoIndex]
@@ -28,6 +28,7 @@ skip = ^Class::Refresh$
 skip = ^Data::Dump$
 skip = ^Data::Printer$
 skip = ^IO::Pager$
+skip = ^PPI$
 skip = ^mro$
 skip = ^MRO::Compat$
 skip = ^Proc::InvokeEditor$
@@ -45,6 +46,7 @@ Class::Refresh = 0.05
 Data::Dump = 0
 Data::Printer = 0
 IO::Pager = 0
+PPI = 0
 Proc::InvokeEditor = 0
 Term::ReadKey = 0
 Term::ReadLine::Gnu = 0

--- a/lib/Reply.pm
+++ b/lib/Reply.pm
@@ -135,7 +135,7 @@ sub step {
             if $verbose;
     }
     else {
-        $line = $self->_read;
+        $line = $self->_wrapped_plugin('read', sub { $self->_read; });
     }
 
     return unless defined $line;

--- a/lib/Reply/Plugin/Defaults.pm
+++ b/lib/Reply/Plugin/Defaults.pm
@@ -120,6 +120,7 @@ sub loop {
   new
   command_q
   command_vars
+  read
 
 =end Pod::Coverage
 

--- a/lib/Reply/Plugin/Defaults.pm
+++ b/lib/Reply/Plugin/Defaults.pm
@@ -42,6 +42,13 @@ BEGIN {
 }
 PREFIX
 
+sub read {
+    my $self = shift;
+    my ($next, $read_coderef) = @_;
+
+    return $read_coderef->();
+}
+
 sub compile {
     my $self = shift;
     my ($next, $line, %args) = @_;

--- a/lib/Reply/Plugin/Multiline/PPI.pm
+++ b/lib/Reply/Plugin/Multiline/PPI.pm
@@ -39,6 +39,14 @@ MultiLine plugin,
 
 you may write the code across multiple lines, such as in C<irb> and C<python>.
 
+=begin Pod::Coverage
+
+# 	continue_reading_if_necessary
+# 	line_needs_continuation
+# 	read
+
+=end Pod::Coverage
+
 =cut
 
 sub new {

--- a/lib/Reply/Plugin/Multiline/PPI.pm
+++ b/lib/Reply/Plugin/Multiline/PPI.pm
@@ -1,0 +1,119 @@
+package Reply::Plugin::Multiline::PPI;
+use strict;
+use warnings;
+# ABSTRACT: command to edit the current line in a text editor
+
+use base 'Reply::Plugin';
+use PPI;
+
+=head1 SYNOPSIS
+
+  ; .replyrc
+  [Multiple::PPI]
+
+=head1 DESCRIPTION
+
+This plugin provides multiline input support for the repl. In fact it is a
+direct port of L<Devel::REPL::Plugin::MultiLine::PPI> plugin for L<Devel::REPL>.
+
+Citing the original:
+
+For example, without a MultiLine plugin,
+
+    $ my $x = 3;
+    3
+    $ if ($x == 3) {
+
+will throw a compile error, because that C<if> statement is incomplete. With a
+MultiLine plugin,
+
+    $ my $x = 3;
+    3
+    $ if ($x == 3) {
+
+    > print "OH NOES!"
+
+    > }
+    OH NOES
+    1
+
+you may write the code across multiple lines, such as in C<irb> and C<python>.
+
+=cut
+
+sub new {
+    my $class = shift;
+    my %opts = @_;
+
+    my $self = $class->SUPER::new(@_);
+    $self->{needs_continuation} = 0;
+
+    return $self;
+}
+
+sub prompt {
+    my $self = shift;
+    my ($next, $read_coderef) = @_;
+
+    return $self->{needs_continuation} ? '... ' : $next->();
+}
+
+sub read {
+    my $self = shift;
+    my ($next, $read_coderef) = @_;
+
+    my $line = $read_coderef->();
+
+    return unless defined $line;
+
+    return $self->continue_reading_if_necessary($line, $read_coderef);
+}
+
+sub continue_reading_if_necessary {
+    my ( $self, $line, $read_coderef ) = @_;
+
+    while ($self->line_needs_continuation($line)) {
+        $self->{needs_continuation} = 1;
+
+        my $append = $read_coderef->();
+
+        $line .= "\n$append" if defined($append);
+
+        $self->{needs_continuation} = 0;
+
+        # ^D means "shut up and eval already"
+        return $line if !defined($append);
+    }
+
+    return $line;
+}
+
+sub line_needs_continuation
+{
+    my $repl = shift;
+    my $line = shift;
+
+    # add this so we can test whether the document ends in PPI::Statement::Null
+    $line .= "\n;;";
+
+    my $document = PPI::Document->new(\$line);
+    return 0 if !defined($document);
+
+    # adding ";" to a complete document adds a PPI::Statement::Null. we added a ;;
+    # so if it doesn't end in null then there's probably something that's
+    # incomplete
+    return 0 if $document->child(-1)->isa('PPI::Statement::Null');
+
+    # this could use more logic, such as returning 1 on s/foo/ba<Enter>
+    my $unfinished_structure = sub
+    {
+        my ($document, $element) = @_;
+        return 0 unless $element->isa('PPI::Structure');
+        return 1 unless $element->finish;
+        return 0;
+    };
+
+    return $document->find_any($unfinished_structure);
+}
+
+1;


### PR DESCRIPTION
Hi!

I adopted Devel::REPL multiline input plugin to use with Reply. Please, let me know if you have any comments regarding implementation.

I decided to go with passing a coderef, because I wanted to run all the hooks reply provides while consuming more lines. In this way other plugins (e.g. Readline) continue working as expected for every line entered, and FancyInput plugin does not conflict with multiline input.