### PR TITLE
Add support for freeze method in Data::Dump and Data::Dumper plugins

### DIFF
--- a/lib/Reply/Plugin/DataDump.pm
+++ b/lib/Reply/Plugin/DataDump.pm
@@ -13,6 +13,7 @@ use overload ();
   ; .replyrc
   [DataDump]
   respect_stringification = 1
+  respect_freeze = 0
 
 =head1 DESCRIPTION
 
@@ -20,6 +21,9 @@ This plugin uses L<Data::Dump> to format results. By default, if it reaches an
 object which has a stringification overload, it will dump that directly. To
 disable this behavior, set the C<respect_stringification> option to a false
 value.
+Also there is feature to reach C<freeze> method, to retrieve
+suitable object instance for dumping.
+Set C<respect_freeze> to enable this behaviour.
 
 =cut
 
@@ -29,16 +33,30 @@ sub new {
     $opts{respect_stringification} = 1
         unless defined $opts{respect_stringification};
 
+    $opts{respect_freeze} = 0
+        unless exists $opts{respect_freeze};
+
     my $self = $class->SUPER::new(@_);
     $self->{filter} = sub {
         my ($ctx, $ref) = @_;
         return unless $ctx->is_blessed;
-        my $stringify = overload::Method($ref, '""');
-        return unless $stringify;
-        return {
-            dump => $stringify->($ref),
-        };
-    } if $opts{respect_stringification};
+
+        if ($opts{respect_stringification}) {
+            my $stringify = overload::Method($ref, '""');
+
+            return {
+                dump => $stringify->($ref),
+            } if $stringify;
+        }
+
+        if ($opts{respect_freeze} && $ref->can('freeze')) {
+            return {
+                object => $ref->freeze(),
+            }
+        }
+
+        return;
+    } if $opts{respect_stringification} || $opts{respect_freeze};
 
     return $self;
 }

--- a/lib/Reply/Plugin/DataDumper.pm
+++ b/lib/Reply/Plugin/DataDumper.pm
@@ -11,18 +11,24 @@ use Data::Dumper;
 
   ; .replyrc
   [DataDumper]
+  respect_freeze = 0
 
 =head1 DESCRIPTION
 
 This plugin uses L<Data::Dumper> to format results.
 
+You can enable C<respect_freeze> feature to force L<Data::Dumper> call
+C<freeze> method to retrieve object suitable for dumping.
+
 =cut
 
 sub new {
     my $class = shift;
+    my %opts = @_;
 
     $Data::Dumper::Terse = 1;
     $Data::Dumper::Sortkeys = 1;
+    $Data::Dumper::Freezer = 'freeze' if $opts{respect_freeze};
 
     return $class->SUPER::new(@_);
 }


### PR DESCRIPTION
This PR adds option to respect `freeze` method in blessed objects.
That object usually used to prepare object for serialization and make that runtime garbage won't be serialized.

```
[DataDump]
  respect_freeze = 0 # disabled by default
```

Enabling this feature will make `Data::Dumper` or `Data::Dump` to call that method prior dumping to retrieve dumpable object. 

Example:

```perl
package My::Awesome::Module;

sub new {
    my ($class) = @_;
    bless({ some_runtime_garbage => 'foo', useful_data => 'bar', $class });
}

sub freeze {
    my ($self) = @_;
 
    my $dumpable_data = { %$self }; # shallow clone

    delete $dumpable_object->{some_runtime_garbage}; # remove runtime garbage

    return bless($dumpable_data, ref($self));
}
```

*Without `respect_freeze` it will look like this:*

```
0> My::Awesome::Module->new()
bless({ some_runtime_garbage => 'foo', useful_data => 'bar', 'My::Awesome::Module'})
```

*With `respect_freeze`*:

```
0> My::Awesome::Module->new()
bless({ useful_data => 'bar', 'My::Awesome::Module'})
```



